### PR TITLE
Autoupdate offset at launch

### DIFF
--- a/dexterion.cpp
+++ b/dexterion.cpp
@@ -33,6 +33,16 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	AllocConsole();
 	freopen("CONOUT$", "w", stdout);
 	HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+
+	// Execute CURL command to update offset JSON
+	SetConsoleTextAttribute(hConsole, 15);
+	system("curl https://raw.githubusercontent.com/a2x/cs2-dumper/main/output/buttons.json > buttons.json");
+	system("curl https://raw.githubusercontent.com/a2x/cs2-dumper/main/output/client.dll.json > client.dll.json");
+	system("curl https://raw.githubusercontent.com/a2x/cs2-dumper/main/output/offsets.json > offsets.json");
+	SetConsoleTextAttribute(hConsole, 10);
+	printf("[MemMan] Required files updated\n");
+
+	
 	// Memory and game related vars (used in entry and passed through overlay)
 	int procId = MemMan.getPid(L"cs2.exe");
 	SetConsoleTextAttribute(hConsole, 9);

--- a/dexterion.cpp
+++ b/dexterion.cpp
@@ -34,6 +34,9 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	freopen("CONOUT$", "w", stdout);
 	HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 
+	SetConsoleTextAttribute(hConsole, 9);
+	printf("[MemMan] Updating required files\n");
+	
 	// Execute CURL command to update offset JSON
 	SetConsoleTextAttribute(hConsole, 15);
 	system("curl https://raw.githubusercontent.com/a2x/cs2-dumper/main/output/buttons.json > buttons.json");


### PR DESCRIPTION
If it can help...
Dexterion still need to have buttins, client.dll & offsets.json in order to boot up...
But if it has them, will download the new offset before running