### PR TITLE
Toggle ESP for Menu and Game Window

### DIFF
--- a/features/bomb.cpp
+++ b/features/bomb.cpp
@@ -1,15 +1,19 @@
 #include "bomb.hpp"
+#include "misc.hpp"
 
 #include <iostream>
 
 void bomb::timer(C_C4 C_C4) {
+	if (!overlayESP::isMenuOpen()) {
+		if (!misc::isGameWindowActive()) return;
+	}
 	bool planted = C_C4.isPlanted();
 	bool defusing = C_C4.isBeingDefused();
 	float defuseTime = C_C4.getDefuseTime();
 
 	static float overlayWidth = 200.f;
 	ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize;
-	ImGui::SetNextWindowPos({ (ImGui::GetIO().DisplaySize.x - overlayWidth) / 2.f, 80.f}, ImGuiCond_FirstUseEver);
+	ImGui::SetNextWindowPos({ (ImGui::GetIO().DisplaySize.x - overlayWidth) / 2.f, 80.f }, ImGuiCond_FirstUseEver);
 	ImGui::SetNextWindowSize({ overlayWidth, 0 }, ImGuiCond_FirstUseEver);
 
 	ImGui::Begin("Bomb Timer", nullptr, flags);
@@ -60,7 +64,7 @@ void bomb::timer(C_C4 C_C4) {
 	}
 
 	ImGui::PushStyleColor(ImGuiCol_PlotHistogram, utils::float3ToImColor(miscConf.bombTimerColours, 1.f).Value);
-	ImGui::ProgressBar(bar, {overlayWidth - 20, 15});
+	ImGui::ProgressBar(bar, { overlayWidth - 20, 15 });
 	ImGui::PopStyleColor();
 	ImGui::End();
 }

--- a/features/entry.cpp
+++ b/features/entry.cpp
@@ -19,6 +19,10 @@ void mainLoop(bool state, MemoryManagement::moduleData client) {
 	localPlayer.getPlayerPawn();
 	// Aimbot FOV circle
 	if (aimConf.fovCircle) {
+		if (!overlayESP::isMenuOpen()) {
+			if (!misc::isGameWindowActive()) return;
+		}
+
 		ImVec2 p = ImGui::GetWindowPos();
 		float screenMidX = GetSystemMetrics(SM_CXSCREEN) / 2.f;
 		float screenMidY = GetSystemMetrics(SM_CYSCREEN) / 2.f;
@@ -89,11 +93,11 @@ void mainLoop(bool state, MemoryManagement::moduleData client) {
 
 			if (espConf.checkSpotted) {
 				if (SharedFunctions::spottedCheck(C_CSPlayerPawn, localPlayer)) {
-					esp::boundingBox(C_CSPlayerPawn.origin, viewMatrix, CCSPlayerController.pawnName, C_CSPlayerPawn.pawnHealth, CGameSceneNode.boneArray,true);
+					esp::boundingBox(C_CSPlayerPawn.origin, viewMatrix, CCSPlayerController.pawnName, C_CSPlayerPawn.pawnHealth, CGameSceneNode.boneArray, true);
 				}
 			}
 			else {
-				esp::boundingBox(C_CSPlayerPawn.origin, viewMatrix, CCSPlayerController.pawnName, C_CSPlayerPawn.pawnHealth, CGameSceneNode.boneArray,SharedFunctions::spottedCheck(C_CSPlayerPawn, localPlayer));
+				esp::boundingBox(C_CSPlayerPawn.origin, viewMatrix, CCSPlayerController.pawnName, C_CSPlayerPawn.pawnHealth, CGameSceneNode.boneArray, SharedFunctions::spottedCheck(C_CSPlayerPawn, localPlayer));
 			}
 		}
 
@@ -110,7 +114,7 @@ void mainLoop(bool state, MemoryManagement::moduleData client) {
 		if (aimConf.state) {
 
 			if (C_CSPlayerPawn.getPlayerPawn() == localPlayer.getPlayerPawn()) continue;
-			
+
 			// Player lock
 			if (aimConf.playerLock) {
 				aim::lockedPlayer = doPreferred(C_CSPlayerPawn, CGameSceneNode, localPlayer, aim::lockedPlayer, viewMatrix, aimConf.aimModeMap[aimConf.aimModes[aimConf.aimMode]], client).playerPawn;
@@ -142,6 +146,10 @@ void mainLoop(bool state, MemoryManagement::moduleData client) {
 	}
 
 	if (miscConf.spectator) {
+		if (!overlayESP::isMenuOpen()) {
+			if (!misc::isGameWindowActive()) return;
+		}
+
 		ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize;
 		ImGui::SetNextWindowPos({ 0.f, 200.f }, ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowSize({ 100.f, 250.f }, ImGuiCond_FirstUseEver);
@@ -158,7 +166,7 @@ void mainLoop(bool state, MemoryManagement::moduleData client) {
 	}
 
 	// Dropped Item
-	if (miscConf.itemESP) misc::droppedItem(C_CSPlayerPawn, CGameSceneNode,viewMatrix);
+	if (miscConf.itemESP) misc::droppedItem(C_CSPlayerPawn, CGameSceneNode, viewMatrix);
 }
 
 C_CSPlayerPawn doPreferred(C_CSPlayerPawn C_CSPlayerPawn_, CGameSceneNode CGameSceneNode, LocalPlayer localPlayer, uintptr_t preferredTarget, view_matrix_t viewMatrix, int mode, MemoryManagement::moduleData client) {

--- a/features/esp.cpp
+++ b/features/esp.cpp
@@ -1,4 +1,5 @@
 #include "esp.hpp"
+#include "misc.hpp"
 
 #include <filesystem>
 
@@ -8,10 +9,10 @@ void esp::makeHealthBar(float health) {
 	float red = (255.f - (health * 2.55f)) - 100.f;
 	float green = (health * 2.55f) / 100.f;
 
-	ImGui::GetBackgroundDrawList()->AddRectFilled({ sharedData::headPosToScreen.x - (sharedData::width + 2.f), sharedData::originalPosToScreen.y - sharedData::height}, { sharedData::headPosToScreen.x - (sharedData::width + 4.5f), sharedData::originalPosToScreen.y }, ImColor(0.f, 0.f, 0.f, 0.3f));
+	ImGui::GetBackgroundDrawList()->AddRectFilled({ sharedData::headPosToScreen.x - (sharedData::width + 2.f), sharedData::originalPosToScreen.y - sharedData::height }, { sharedData::headPosToScreen.x - (sharedData::width + 4.5f), sharedData::originalPosToScreen.y }, ImColor(0.f, 0.f, 0.f, 0.3f));
 	ImGui::GetBackgroundDrawList()->AddRectFilled({ sharedData::headPosToScreen.x - (sharedData::width + 2.f), sharedData::originalPosToScreen.y - healthBarYOffset }, { sharedData::headPosToScreen.x - (sharedData::width + 4.5f), sharedData::originalPosToScreen.y }, ImColor(red, green, 0.f, 1.f));
 	if (espConf.hpCounter) {
-		ImGui::GetBackgroundDrawList()->AddText(imGuiMenu::espNameText, getFontSize(sideESPText,distance), {sharedData::headPosToScreen.x - (sharedData::width + 10.f), sharedData::originalPosToScreen.y - healthBarYOffset - 12.f}, ImColor(espConf.attributeColours[0], espConf.attributeColours[1], espConf.attributeColours[2]), std::to_string((int)health).c_str());
+		ImGui::GetBackgroundDrawList()->AddText(imGuiMenu::espNameText, getFontSize(sideESPText, distance), { sharedData::headPosToScreen.x - (sharedData::width + 10.f), sharedData::originalPosToScreen.y - healthBarYOffset - 12.f }, ImColor(espConf.attributeColours[0], espConf.attributeColours[1], espConf.attributeColours[2]), std::to_string((int)health).c_str());
 	}
 }
 
@@ -33,7 +34,7 @@ void esp::makeSkeleton(view_matrix_t viewMatrix, uintptr_t boneArray) {
 		if (espConf.head) {
 			Vector3 headBone = MemMan.ReadMem<Vector3>(boneArray + bones::head * 32);
 			Vector3 headBonePos = headBone.worldToScreen(viewMatrix);
-			ImGui::GetBackgroundDrawList()->AddCircle({ headBonePos.x,headBonePos.y }, 40.f/(distance == 0 ? 1 : distance), headColour);
+			ImGui::GetBackgroundDrawList()->AddCircle({ headBonePos.x,headBonePos.y }, 40.f / (distance == 0 ? 1 : distance), headColour);
 		}
 
 		if (espConf.joint) ImGui::GetBackgroundDrawList()->AddCircleFilled({ b1.x, b1.y }, getJointSize(5.f, distance), jointColour);
@@ -45,9 +46,9 @@ void esp::makeSkeleton(view_matrix_t viewMatrix, uintptr_t boneArray) {
 
 void esp::makeName(std::string name) {
 	ImVec2 textSize = ImGui::CalcTextSize(name.c_str());
-	auto [horizontalOffset, verticalOffset] =  getTextOffsets(textSize.x,textSize.y, 2.f);
+	auto [horizontalOffset, verticalOffset] = getTextOffsets(textSize.x, textSize.y, 2.f);
 
-	ImGui::GetBackgroundDrawList()->AddText(imGuiMenu::espNameText, getFontSize(normalESPText, distance), {sharedData::headPosToScreen.x - horizontalOffset, sharedData::headPosToScreen.y - verticalOffset}, ImColor(espConf.attributeColours[0], espConf.attributeColours[1], espConf.attributeColours[2]), name.c_str());
+	ImGui::GetBackgroundDrawList()->AddText(imGuiMenu::espNameText, getFontSize(normalESPText, distance), { sharedData::headPosToScreen.x - horizontalOffset, sharedData::headPosToScreen.y - verticalOffset }, ImColor(espConf.attributeColours[0], espConf.attributeColours[1], espConf.attributeColours[2]), name.c_str());
 }
 
 
@@ -77,7 +78,7 @@ void esp::makeDistance() {
 
 	auto [horizontalOffset, verticalOffset] = getTextOffsets(textSize.x, textSize.y, 2.f);
 
-	ImGui::GetBackgroundDrawList()->AddText(imGuiMenu::espNameText, getFontSize(sideESPText, distance), { sharedData::headPosToScreen.x - horizontalOffset, sharedData::headPosToScreen.y - verticalOffset - 12}, ImColor(espConf.attributeColours[0], espConf.attributeColours[1], espConf.attributeColours[2]), distanceText.c_str());
+	ImGui::GetBackgroundDrawList()->AddText(imGuiMenu::espNameText, getFontSize(sideESPText, distance), { sharedData::headPosToScreen.x - horizontalOffset, sharedData::headPosToScreen.y - verticalOffset - 12 }, ImColor(espConf.attributeColours[0], espConf.attributeColours[1], espConf.attributeColours[2]), distanceText.c_str());
 }
 
 void esp::drawC4(Vector3 origin, view_matrix_t viewMatrix, LocalPlayer localPlayer, C_C4 C_C4) {
@@ -88,7 +89,7 @@ void esp::drawC4(Vector3 origin, view_matrix_t viewMatrix, LocalPlayer localPlay
 	float distance = utils::getDistance(localPlayer.getOrigin(), origin);
 
 	if (c4PosToScreen.z <= 0.f) return; // Check if C4 is behind the player
-	
+
 	float height = 5000 / distance;
 	float width = height * 1.2f;
 
@@ -98,9 +99,12 @@ void esp::drawC4(Vector3 origin, view_matrix_t viewMatrix, LocalPlayer localPlay
 	Render::DrawGradientLine({ boxX, boxY }, { width + boxX, height + boxY }, ImColor(espConf.c4Colors[0], espConf.c4Colors[1], espConf.c4Colors[2], 1.f), (espConf.c4Gradient ? ImColor(espConf.c4ColorsGradient[0], espConf.c4ColorsGradient[1], espConf.c4ColorsGradient[2], 1.f) : ImColor(espConf.c4Colors[0], espConf.c4Colors[1], espConf.c4Colors[2], 1.f)), espConf.c4Thickness);
 }
 
-
 void esp::boundingBox(Vector3 origin, view_matrix_t viewMatrix, std::string name, int health, uintptr_t boneArray, bool isSpotted) {
 	if (origin.IsZero()) return;
+
+	if (!overlayESP::isMenuOpen()) {
+		if (!misc::isGameWindowActive()) return;
+	}
 
 	Vector3 originalPosToScreen = origin.worldToScreen(viewMatrix);
 	sharedData::originalPosToScreen = originalPosToScreen;
@@ -128,7 +132,7 @@ void esp::boundingBox(Vector3 origin, view_matrix_t viewMatrix, std::string name
 			else Render::DrawGradientLine({ headPosToScreen.x - width, headPosToScreen.y }, { headPosToScreen.x + width, originalPosToScreen.y }, ImColor(espConf.cornerColours[0], espConf.cornerColours[1], espConf.cornerColours[2], 1.f), ImColor(espConf.cornerGradient[0], espConf.cornerGradient[1], espConf.cornerGradient[2], 1.f), espConf.boundBoxThickness);
 			if (espConf.filledBox) ImGui::GetBackgroundDrawList()->AddRectFilled({ headPosToScreen.x - width, headPosToScreen.y }, { headPosToScreen.x + width, originalPosToScreen.y }, filledBoxcolour, 0.f, 0.f);
 		}
-		
+
 		if (espConf.isHealthBar) {
 			makeHealthBar(health);
 		}

--- a/features/misc.cpp
+++ b/features/misc.cpp
@@ -1,5 +1,14 @@
 #include "misc.hpp"
 
+bool misc::isGameWindowActive() {
+	HWND hwnd = GetForegroundWindow();
+	if (hwnd) {
+		char windowTitle[256];
+		GetWindowTextA(hwnd, windowTitle, sizeof(windowTitle));
+		return std::string(windowTitle).find("Counter-Strike 2") != std::string::npos;
+	}
+	return false;
+}
 
 void misc::bunnyHop(DWORD_PTR base, int flags) {
 	if (GetAsyncKeyState(VK_SPACE) && flags & bhopInAir) {
@@ -11,6 +20,10 @@ void misc::bunnyHop(DWORD_PTR base, int flags) {
 }
 
 void misc::droppedItem(C_CSPlayerPawn C_CSPlayerPawn, CGameSceneNode CGameSceneNode, view_matrix_t viewMatrix) {
+	if (!overlayESP::isMenuOpen()) {
+		if (!misc::isGameWindowActive()) return;
+	}
+
 	for (int i = 65; i < 1024; i++) {
 		// Entity
 		C_CSPlayerPawn.value = i;
@@ -24,7 +37,7 @@ void misc::droppedItem(C_CSPlayerPawn C_CSPlayerPawn, CGameSceneNode CGameSceneN
 		uintptr_t entity = MemMan.ReadMem<uintptr_t>(C_CSPlayerPawn.playerPawn + 0x10);
 		uintptr_t designerNameAddy = MemMan.ReadMem<uintptr_t>(entity + 0x20);
 
-		char designerNameBuffer[MAX_PATH]{}; 
+		char designerNameBuffer[MAX_PATH]{};
 		MemMan.ReadRawMem(designerNameAddy, designerNameBuffer, MAX_PATH);
 
 		std::string name = std::string(designerNameBuffer);

--- a/features/misc.hpp
+++ b/features/misc.hpp
@@ -4,6 +4,7 @@
 
 #include "../util/config.hpp"
 #include "../gui/menu.hpp"
+#include "../gui/overlay.hpp"
 
 namespace misc {
 
@@ -13,4 +14,5 @@ namespace misc {
 
 	void bunnyHop(DWORD_PTR base, int flags);
 	void droppedItem(C_CSPlayerPawn C_CSPlayerPawn, CGameSceneNode CGameSceneNode, view_matrix_t viewMatrix);
+	bool isGameWindowActive();
 }

--- a/gui/overlay.cpp
+++ b/gui/overlay.cpp
@@ -105,10 +105,10 @@ void overlayESP::initWindow(int nShowCmd) {
 	printf("[overlay.cpp] Overlay Drew Succesfully!\n");
 }
 
-bool overlayESP::menuOpen = false;
+bool overlayESP::menutoggle = true;
 
 bool overlayESP::isMenuOpen() {
-	return menutoggle;
+	return !menutoggle;
 }
 
 void overlayESP::renderLoop(MemoryManagement::moduleData client) {

--- a/gui/overlay.cpp
+++ b/gui/overlay.cpp
@@ -108,18 +108,15 @@ void overlayESP::initWindow(int nShowCmd) {
 bool overlayESP::menuOpen = false;
 
 bool overlayESP::isMenuOpen() {
-	return menuOpen;
+	return menutoggle;
 }
 
 void overlayESP::renderLoop(MemoryManagement::moduleData client) {
 	bool state = true;
-	bool menutoggle = true;
 
 	while (state) {
-		if (GetAsyncKeyState(VK_INSERT) & 1) {
+		if (GetAsyncKeyState(VK_INSERT) & 1)
 			menutoggle = !menutoggle;
-			menuOpen = menutoggle;
-		}
 
 		MSG msg;
 		while (PeekMessage(&msg, 0, 0, 0, PM_REMOVE)) {

--- a/gui/overlay.cpp
+++ b/gui/overlay.cpp
@@ -9,7 +9,7 @@
 
 #include "../features/entry.hpp"
 
-WNDCLASSEXW overlayESP::createWindowClass(HINSTANCE hInstance,WNDPROC Wndproc, LPCWSTR windowname) {
+WNDCLASSEXW overlayESP::createWindowClass(HINSTANCE hInstance, WNDPROC Wndproc, LPCWSTR windowname) {
 	this->hInstance = hInstance;
 
 	windowClass.cbSize = sizeof(WNDCLASSEXA);
@@ -89,7 +89,7 @@ void overlayESP::initWindow(int nShowCmd) {
 	ImGui::CreateContext();
 	ImGuiIO& io = ImGui::GetIO();
 	io.Fonts->AddFontDefault();
-	imGuiMenu::normalText= io.Fonts->AddFontFromFileTTF("C:\\Windows\\Fonts\\Verdana.ttf", 15.f);
+	imGuiMenu::normalText = io.Fonts->AddFontFromFileTTF("C:\\Windows\\Fonts\\Verdana.ttf", 15.f);
 	imGuiMenu::titleText = io.Fonts->AddFontFromFileTTF("C:\\Windows\\Fonts\\verdanab.ttf", 16.f);
 	imGuiMenu::subTitleText = io.Fonts->AddFontFromFileTTF("C:\\Windows\\Fonts\\verdanab.ttf", 15.f);
 	imGuiMenu::highlightText = io.Fonts->AddFontFromFileTTF("C:\\Windows\\Fonts\\verdanai.ttf", 13.f);
@@ -105,13 +105,20 @@ void overlayESP::initWindow(int nShowCmd) {
 	printf("[overlay.cpp] Overlay Drew Succesfully!\n");
 }
 
+bool overlayESP::menuOpen = false;
+
+bool overlayESP::isMenuOpen() {
+	return menuOpen;
+}
+
 void overlayESP::renderLoop(MemoryManagement::moduleData client) {
 	bool state = true;
 	bool menutoggle = true;
 
-	while (state){
-		if (GetAsyncKeyState(VK_INSERT) & 1){
+	while (state) {
+		if (GetAsyncKeyState(VK_INSERT) & 1) {
 			menutoggle = !menutoggle;
+			menuOpen = menutoggle;
 		}
 
 		MSG msg;
@@ -137,7 +144,7 @@ void overlayESP::renderLoop(MemoryManagement::moduleData client) {
 		ImGui_ImplWin32_NewFrame();
 		ImGui::NewFrame();
 
-		mainLoop(state,client);
+		mainLoop(state, client);
 
 		if (menutoggle) {
 			imGuiMenu::renderMenu(state);
@@ -157,7 +164,7 @@ void overlayESP::renderLoop(MemoryManagement::moduleData client) {
 
 		loadedSwapChain->Present(1, 0);
 
-		std::this_thread::sleep_for(std::chrono::milliseconds(1/100));
+		std::this_thread::sleep_for(std::chrono::milliseconds(1 / 100));
 	}
 }
 

--- a/gui/overlay.hpp
+++ b/gui/overlay.hpp
@@ -20,7 +20,6 @@ public:
 	HINSTANCE hInstance;
 	WNDCLASSEXW windowClass;
 	HWND window;
-	bool menutoggle = true;
 
 	DXGI_SWAP_CHAIN_DESC swapChain{};
 	D3D_FEATURE_LEVEL featureLevels[2]{
@@ -34,7 +33,7 @@ public:
 	D3D_FEATURE_LEVEL loadedLevel{};
 	ID3D11Texture2D* backBuffer{ 0 };
 
-	static bool menuOpen;
+	static bool menutoggle;
 	static bool isMenuOpen();
 	WNDCLASSEXW createWindowClass(HINSTANCE hInstance, WNDPROC Wndproc, LPCWSTR windowname);
 

--- a/gui/overlay.hpp
+++ b/gui/overlay.hpp
@@ -33,8 +33,9 @@ public:
 	D3D_FEATURE_LEVEL loadedLevel{};
 	ID3D11Texture2D* backBuffer{ 0 };
 
-
-	WNDCLASSEXW createWindowClass(HINSTANCE hInstance,WNDPROC Wndproc,LPCWSTR windowname);
+	static bool menuOpen;
+	static bool isMenuOpen();
+	WNDCLASSEXW createWindowClass(HINSTANCE hInstance, WNDPROC Wndproc, LPCWSTR windowname);
 
 	HWND createWindow(int horizontalSize, int verticallSize);
 

--- a/gui/overlay.hpp
+++ b/gui/overlay.hpp
@@ -20,6 +20,7 @@ public:
 	HINSTANCE hInstance;
 	WNDCLASSEXW windowClass;
 	HWND window;
+	bool menutoggle = true;
 
 	DXGI_SWAP_CHAIN_DESC swapChain{};
 	D3D_FEATURE_LEVEL featureLevels[2]{


### PR DESCRIPTION
Modify the overlay to only display visuals when the menu is open or when CS2 is the active window, so there is a cleaner user experience (especially when e.g. tabbing out of cs2 to chat with a friend)

PS: this is probably not a well written version and more of a Proof-of-Concept/ enhancement idea
Would be cool to see something similar in Dexterion though as it is getting a bit annoying :)